### PR TITLE
Change default value for OPENCMISSEXAMPLES_ROOT

### DIFF
--- a/ExampleMakefile
+++ b/ExampleMakefile
@@ -69,7 +69,7 @@ else
 endif
 
 ifndef OPENCMISSEXAMPLES_ROOT
-  OPENCMISSEXAMPLES_ROOT := $(GLOBAL_ROOT)/examples
+  OPENCMISSEXAMPLES_ROOT := $(GLOBAL_ROOT)/../examples
 endif
 
 include $(EXTERNAL_UTILS_ROOT)/Makefile.inc


### PR DESCRIPTION
Set it to OPENCMISS_ROOT/examples rather than OPENCMISS_ROOT/cm/examples
