### PR TITLE
Add "make test" in Makefile to test all and/or selected examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2317,9 +2317,8 @@ ifndef DIR
   DIR=.
 endif
 
-test: 
+test: main
 	@echo "================================================================================================"
-	@echo "Please make sure the library is built before test."
 	@echo "By default, this will test small set of examples. (All tests in the nightly build)"
 	@echo "To test large set of examples (All tests in the nightly build), please set SIZE=large"
 	@echo "To test examples inside a given directory, please set DIR=<DIR>, e.g. DIR=ClassicalField/Laplace"


### PR DESCRIPTION
The test target is added to the Makefile. In order to run "make test", the
OpenCMISS library should be built. The python testing tool, nose, should be
installed. By default, it will build with Intel compiler on a small set of
tests (those executed in the nightly build) under <OPENCMISSEXAMPLES_ROOT>
directory. There are three options for the target:
- COMPILER=(intel|gnu)
- SIZE=(small|large), small for those tested in nightly build, large for those
  tested in the weekly build. 
- DIR=(DIR), will test examples under DIR from <OPENCMISSEXAMPLES_ROOT> only. 
  Please see https://tracker.physiomeproject.org/show_bug.cgi?id=3013 for details.
