### PR TITLE
Make sure that programs exit with the error code

### DIFF
--- a/src/base_routines.f90
+++ b/src/base_routines.f90
@@ -1377,8 +1377,6 @@ CONTAINS
     ENDDO
     WRITE(OP_STRING,'(A)') INDENT_STRING(1:INDENT)//CHAR(ERROR)
     CALL WRITE_STR(ERROR_OUTPUT_TYPE,LOCAL_ERR,LOCAL_ERROR2,*999)
-    ERR=0
-    ERROR=""
 
     RETURN
     !Don't return an error code here otherwise we will get into a circular loop


### PR DESCRIPTION
When the error handling mode is set to CMISSTrapError, the program
should exit with the error code, rather than zero.

Calling WRITE_ERROR was resetting the error code to zero before exiting.

[Tracker item 3029](https://tracker.physiomeproject.org/show_bug.cgi?id=3029)
