### PR TITLE
Fix exception class in Python bindings

### DIFF
--- a/bindings/python/opencmiss/_utils.py
+++ b/bindings/python/opencmiss/_utils.py
@@ -7,11 +7,7 @@ import _opencmiss_swig
 class CMISSError(Exception):
     """Base class for errors in the OpenCMISS library"""
 
-    def __init__(self, value):
-        self.value = value
-
-    def __str__(self):
-        return repr(self.value)
+    pass
 
 
 class CMISSType(object):


### PR DESCRIPTION
The custom constructor isn't needed and was causing problems when exceptions were raised when running in a pool with the multiprocessing module, as it expected the constructor to take two arguments.
