### PR TITLE
Add the -lpthread flag to link OpenMPI library.

### DIFF
--- a/utils/MakefileCommon.inc
+++ b/utils/MakefileCommon.inc
@@ -942,7 +942,7 @@ ifeq ($(OPERATING_SYSTEM),linux)# Linux
       ifeq ($(MPI),openmpi)
         MPI_INCLUDE_PATH += $(addprefix -I, $(MPI_DIR)/include/ )
         MPI_INCLUDE_PATH += $(addprefix -I, $(MPI_DIR)/lib/ )
-        MPI_LIBRARIES += -lmpi_f90 -lmpi_f77 -lmpi -libverbs -lnsl -lutil -ldl -lnsl -lutil
+        MPI_LIBRARIES += -lmpi_f90 -lmpi_f77 -lmpi -libverbs -lnsl -lutil -ldl -lnsl -lutil -lpthread
         MPI_LIB_PATH += $(addprefix -L, $(MPI_DIR)/lib/ )
       else
         ifeq ($(MPI),mvapich2)


### PR DESCRIPTION
Tiny change, no relevant tracker item.
