### PR TITLE
Fix example linking errors with new OC-extras libraries

### DIFF
--- a/utils/MakefileCommon.inc
+++ b/utils/MakefileCommon.inc
@@ -513,7 +513,7 @@ MUMPS_INCLUDE_PATH =#
 MUMPS_LIBRARIES =#
 MUMPS_LIB_PATH =#
 ifeq (${OPENCMISS_USE_MUMPS},true)
-  MUMPS_LIBRARIES += $(call convertlistlink,$(OCE_BLACSLIBS)) $(call convertlistlink,$(OCE_SCALAPACKLIBS)) -ldmumps -lmumps_common -lpord
+  MUMPS_LIBRARIES += $(call convertlistlink,$(OCE_BLACSLIBS)) -ldmumps -lmumps_common -lpord $(call convertlistlink,$(OCE_SCALAPACKLIBS))
   MUMPS_LIB_PATH += $(addprefix -L, $(OCE_BLACSLIBPATH) )
   MUMPS_LIB_PATH += $(addprefix -L, $(OCE_SCALAPACKLIBPATH) )
   MUMPS_LIB_PATH += $(addprefix -L, $(OCE_CM_INSTALL_DIR)/lib )


### PR DESCRIPTION
Fix MUMPS linking errors during example compile by listing ScaLAPACK lib behind MUMPS libs. NRTI
