### PR TITLE
Revert loading dynamic libraries in Python bindings with RTLD_GLOBAL

### DIFF
--- a/bindings/generate_bindings/python.py
+++ b/bindings/generate_bindings/python.py
@@ -15,14 +15,6 @@ This Python module wraps the underlying OpenCMISS Fortran library.
 http://www.opencmiss.org
 """)
 
-DLOPEN_FIX = ("""# Make symbols from dynamically imported libraries global so
-# that the Intel MKL library can be loaded correctly when used
-import sys
-import ctypes
-if hasattr(sys, "setdlopenflags"):
-    sys.setdlopenflags(sys.getdlopenflags() | ctypes.RTLD_GLOBAL)
-""")
-
 INITIALISE = """WorldCoordinateSystem = CoordinateSystem()
 WorldRegion = Region()
 Initialise(WorldCoordinateSystem, WorldRegion)
@@ -49,7 +41,6 @@ def generate(cm_path, args):
     library = LibrarySource(cm_path)
 
     module.write('"""%s"""\n\n' % MODULE_DOCSTRING)
-    module.write(DLOPEN_FIX)
     module.write("import _opencmiss_swig\n")
     module.write("import signal\n")
     module.write("from _utils import (CMISSError, CMISSType, Enum,\n"


### PR DESCRIPTION
[Tracker item 3504.](https://tracker.physiomeproject.org/show_bug.cgi?id=3504)

This fixes a segfault when loading numpy after OpenCMISS in the Python bindings. I've updated OpenCMISS extras to use the single dynamic MKL library, libmkl_rt, so setting RTLD_GLOBAL is no longer required.

There's a segfault when using CMISSDistributedMatrix_DataRestore on a PETSc matrix, but this is unrelated to this change and is because matrestorearrayf90 in PETSc thinks matrix data should be a 2D Fortran array, which makes no sense for a sparse matrix. I'm not sure why this issue didn't come up previously, but I'll report this as a bug in the tracker and in PETSc (Why don't they have a proper bug tracker???).
