### PR TITLE
Work around PETSc expecting a 2D array for matrix data

### DIFF
--- a/src/cmiss_petsc.f90
+++ b/src/cmiss_petsc.f90
@@ -745,7 +745,7 @@ MODULE CMISS_PETSC
         
     SUBROUTINE MatRestoreArrayF90(A,mat_data,ierr)
       Mat A
-      PetscScalar, POINTER :: mat_data(:)
+      PetscScalar, POINTER :: mat_data(:,:)
       PetscInt ierr
     END SUBROUTINE MatRestoreArrayF90
     
@@ -3528,7 +3528,7 @@ CONTAINS
 
     !Argument Variables
     TYPE(PETSC_MAT_TYPE), INTENT(INOUT) :: A !<The matrix to restore the array for
-    REAL(DP), POINTER :: ARRAY(:) !<A pointer to the matrix array to restore
+    REAL(DP), POINTER :: ARRAY(:,:) !<A pointer to the matrix array to restore
     INTEGER(INTG), INTENT(OUT) :: ERR !<The error code
     TYPE(VARYING_STRING), INTENT(OUT) :: ERROR !<The error string
     !Local Variables


### PR DESCRIPTION
[Tracker item 3514](https://tracker.physiomeproject.org/show_bug.cgi?id=3514)

In distributed_matrix_data_restore, PETSc expects a 2D array of matrix data, even for sparse matrices.
