### PR TITLE
Update to the latest version of buildbot configuration script

### DIFF
--- a/buildbot/OpenCMISS.cfg
+++ b/buildbot/OpenCMISS.cfg
@@ -101,18 +101,18 @@ compilers_list = ['intel','gnu_system','gnu_opencmiss']
 
 for system in systems_list :
     for compiler in compilers_list :
-	if system != 'i686-linux' or compiler !='intel' :
-	        c['builders'].append(
-        	        {'name':'%s-%s-OpenCMISSExtras' %(system, compiler),
-                	 'slavename':'%s-%s' %(system, compiler),
-                 	'builddir':'%s-%s/OpenCMISSExtras' %(system, compiler),
-                 	'factory':f_linux_OpenCMISSExtras})
+        if system != 'i686-linux' or compiler !='intel' :
+            c['builders'].append(
+                {'name':'%s-%s-OpenCMISSExtras' %(system, compiler),
+                'slavename':'%s-%s' %(system, compiler),
+                'builddir':'%s-%s/OpenCMISSExtras' %(system, compiler),
+                'factory':f_linux_OpenCMISSExtras})
 
-        	c['builders'].append(
-               		{'name':'%s-%s-OpenCMISS' %(system, compiler),
-                	'slavename':'%s-%s' %(system, compiler),
-                	'builddir':'%s-%s/OpenCMISS' %(system, compiler),
-                	'factory':f_linux_OpenCMISS})
+            c['builders'].append(
+                {'name':'%s-%s-OpenCMISS' %(system, compiler),
+                'slavename':'%s-%s' %(system, compiler),
+                'builddir':'%s-%s/OpenCMISS' %(system, compiler),
+                'factory':f_linux_OpenCMISS})
 
 c['builders'].append(
     {'name':'documentation',


### PR DESCRIPTION
Main changes:
- Build optimised version of OpenCMISS-Iron on buildbot
- Hide some unimportant buildsteps
- Add a build step to clean build logs that are more than 30 days old. 
