### PR TITLE
Fix error in numpy typemap for 2D array input

### DIFF
--- a/bindings/python/numpy.i
+++ b/bindings/python/numpy.i
@@ -908,7 +908,7 @@
   (PyArrayObject* array=NULL, int is_new_object=0)
 {
   npy_intp size[2] = { -1, -1 };
-  array = obj_to_array_contiguous_allow_conversion($input,
+  array = obj_to_array_fortran_allow_conversion($input,
                                                    DATA_TYPECODE,
                                                    &is_new_object);
   if (!array || !require_dimensions(array, 2) ||


### PR DESCRIPTION
This fixes the issue Sander emailed the developers list about.
The numpy.i file from numpy has an error in it where 2D input arrays aren't created with Fortran ordering.
