### PR TITLE
Fix to use new run test script.

### DIFF
--- a/ExampleMakefile
+++ b/ExampleMakefile
@@ -155,7 +155,7 @@ run : main
 	$(EXECUTABLE)
 
 test:	main
-	DIR=$(EXAMPLE_ROOT) python $(OPENCMISSEXAMPLES_ROOT)/scripts/run_tests.py 
+	DIR=$(EXAMPLE_PATH)$(EXAMPLE_NAME) python $(OPENCMISSEXAMPLES_ROOT)/scripts/run_tests.py 
 
 callgrindrun : main
 	valgrind --tool=callgrind $(EXECUTABLE)


### PR DESCRIPTION
Fix to use the updated run test script from pull https://github.com/OpenCMISS/examples/pull/96 that allows you to type make test in an example directory.